### PR TITLE
[fix] ProductCard 컴포넌트 가격 null 값 처리

### DIFF
--- a/src/components/common/ProductCard.tsx
+++ b/src/components/common/ProductCard.tsx
@@ -59,7 +59,11 @@ const ProductCard: React.FC<ProductCardProps> = ({
         }
     };
 
-    const formatPrice = (price: number): string => {
+    const formatPrice = (price: number | null | undefined): string => {
+        // null, undefined, 또는 숫자가 아닌 값 처리
+        if (price == null || isNaN(price)) {
+            return '₩0';
+        }
         return `₩${price.toLocaleString()}`;
     };
 


### PR DESCRIPTION
## 📌 PR 제목


---

## 📄 개요
 문제 상황
- ProductCard 컴포넌트에서 `Cannot read properties of null (reading 'toLocaleString')` TypeError 발생
- formatPrice 함수에서 price 값이 null일 때 toLocaleString() 메서드 호출 시 오류 발생
- 판매자스토어페이지에서 홈이동시 오류발생 

---

## ✅ 작업 내용
<!-- 체크박스를 채우며 어떤 작업을 했는지 명확히 표현해주세요 -->
- [ ] 기능 구현
- [ ] UI/UX 수정
- [x] API 연동
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 문서 작성

---

## 📃 작업 세부 내용


 해결 방법
- formatPrice 함수에 null/undefined 안전성 추가
- price가 null, undefined, 또는 숫자가 아닌 경우 기본값 '₩0' 반환

 📝 변경 사항
```typescript
// Before
const formatPrice = (price: number): string => {
    return `₩${price.toLocaleString()}`;
};

// After  
const formatPrice = (price: number | null | undefined): string => {
    if (price == null || isNaN(price)) {
        return '₩0';
    }
    return `₩${price.toLocaleString()}`;
};
```

---

## 🔍 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 (예: #23) -->
- #24 

---

## 📝 참고 사항
<!-- 리뷰어가 참고할 만한 내용을 자유롭게 작성해주세요 -->
- 

---

## 🙏 리뷰 요청 사항
<!-- 특별히 리뷰어에게 받고 싶은 피드백이 있다면 작성해주세요 -->
- 
